### PR TITLE
Configure Dependabot to update Doctocat

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "npm" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-name: "@primer/gatsby-theme-doctocat"


### PR DESCRIPTION
## Problem

Every time we release a new version of [Doctocat](https://primer.style/doctocat), we have to manually update every Doctocat site. This process is tedious, and sites can easily be forgotten. 

## Solution

This PR configures dependabot to automatically update Doctocat every time a new version is released.